### PR TITLE
Fix segfault on non-existant files and clean up memory leaks

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -59,7 +59,7 @@ test:
 
 
 debug:
-	$(CC) $(CFLAGS) -D DEBUG=1 main.c $(src_files) -o debug_$(bin_name)
+	$(CC) $(CFLAGS) -g -fsanitize=address,undefined -D DEBUG=1 main.c $(src_files) -o debug_$(bin_name)
 
 
 # clean target: remove all object files and binary

--- a/src/mmv.c
+++ b/src/mmv.c
@@ -65,19 +65,13 @@ struct Set *init_src_set(const int num_keys, char *argv[], struct Opts *options)
         if (path == NULL) {
             fprintf(stderr,"mmv: error opening '%s': ",argv[i]);
             perror(NULL);
-            for (int j = 0; j < i; j++)
-              free(realpath_argv[j]);
-
-            free(realpath_argv);
+            free_strarr(realpath_argv,i);
             return NULL;
         }
         if (cpy_str_to_arr(&realpath_argv[i], path) == NULL)
         {
             free(path);
-            for (int j = 0; j < i; j++)
-              free(realpath_argv[j]);
-
-            free(realpath_argv);
+            free_strarr(realpath_argv,i);
             return NULL;
         }
         free(path);
@@ -88,7 +82,7 @@ struct Set *init_src_set(const int num_keys, char *argv[], struct Opts *options)
 
     if (realpath_set == NULL)
     {
-        free(realpath_argv);
+        free_strarr(realpath_argv,num_keys);
         return NULL;
     }
 
@@ -102,19 +96,22 @@ struct Set *init_src_set(const int num_keys, char *argv[], struct Opts *options)
         for (key = set_begin(realpath_set); key < set_end_pos; key = set_next(key))
             if (is_valid_key(key))
             {
+                free(realpath_argv[key_num]);
                 if (cpy_str_to_arr(&realpath_argv[key_num], argv[key_num]) == NULL)
                 {
-                    free(src_set);
+                    free_strarr(realpath_argv,num_keys);
+                    set_destroy(src_set);
                     return NULL;
                 }
 
                 key_num++;
             }
 
+        set_destroy(realpath_set);
         src_set = set_init(false, key_num, realpath_argv, false);
     }
 
-    free(realpath_argv);
+    free_strarr(realpath_argv,num_keys);
 
     return src_set;
 }
@@ -135,7 +132,13 @@ struct Set *init_dest_set(unsigned int num_keys, char path[])
         return NULL;
     }
 
+    // setting this to true causes no leak, leak can be found with valgrind
     struct Set *set = set_init(false, dest_size, dest_arr, true);
+    if (set == NULL) {
+            free_strarr(dest_arr, dest_size);
+            fprintf(stderr,"mmv: failed init_dest_set\n");
+            return NULL;
+    }
 
     free_strarr(dest_arr, dest_size);
 

--- a/src/mmv.c
+++ b/src/mmv.c
@@ -190,11 +190,12 @@ int rename_paths(struct Set *src_set, struct Set *dest_set, struct Opts *opts)
     for (i = set_begin(src_set), j = set_begin(dest_set); i < set_end(src_set) && j < set_end(dest_set);
          i = set_next(i), j = set_next(j))
     {
-        src_str  = *get_set_pos(src_set, i);
-        dest_str = *get_set_pos(dest_set, j);
-
         if (is_valid_key(j))
+        {
+            src_str  = *get_set_pos(src_set, i);
+            dest_str = *get_set_pos(dest_set, j);
             rename_path(src_str, dest_str, opts);
+        }
     }
 
     return 0;

--- a/src/mmv.c
+++ b/src/mmv.c
@@ -60,12 +60,28 @@ struct Set *init_src_set(const int num_keys, char *argv[], struct Opts *options)
         return NULL;
     }
 
-    for (int i = 0; i < num_keys; i++)
-        if (cpy_str_to_arr(&realpath_argv[i], realpath(argv[i], NULL)) == NULL)
-        {
+    for (int i = 0; i < num_keys; i++) {
+        char* path = realpath(argv[i],NULL);
+        if (path == NULL) {
+            fprintf(stderr,"mmv: error opening '%s': ",argv[i]);
+            perror(NULL);
+            for (int j = 0; j < i; j++)
+              free(realpath_argv[j]);
+
             free(realpath_argv);
             return NULL;
         }
+        if (cpy_str_to_arr(&realpath_argv[i], path) == NULL)
+        {
+            free(path);
+            for (int j = 0; j < i; j++)
+              free(realpath_argv[j]);
+
+            free(realpath_argv);
+            return NULL;
+        }
+        free(path);
+    }
 
     // turn array of absolute paths into a set to rm duplicates
     struct Set *realpath_set = set_init(options->resolve_paths, num_keys, realpath_argv, true);

--- a/src/set.c
+++ b/src/set.c
@@ -148,9 +148,12 @@ struct Set *set_init(bool resolve_paths, const int arg_count, char *args[], bool
         {
             set_destroy(set);
             fprintf(stderr, "mmv: failed to insert \'%s\': %s\n", cur_str, strerror(errno));
-            free(cur_str);
+            if (resolve_paths)
+                free(cur_str);
             return NULL;
         }
+        if (resolve_paths)
+            free(cur_str);
     }
 
     return set;

--- a/src/set.c
+++ b/src/set.c
@@ -66,6 +66,11 @@ static int set_insert(char *cur_str, struct Set *set, bool track_dupes)
     long unsigned int hash = hash_str(cur_str, set->map_capacity);
     int is_dupe            = is_duplicate_element(cur_str, set, &hash);
 
+    if (set->num_keys >= set->map_capacity) {
+      fprintf(stderr, "mmv: set capacity reached, cannot insert '%s'\n", cur_str);
+      return -1;
+    }
+
     if (is_dupe == 0)
     {
         if (track_dupes)
@@ -133,11 +138,17 @@ struct Set *set_init(bool resolve_paths, const int arg_count, char *args[], bool
         cur_str = args[i];
         if (resolve_paths)
             cur_str = realpath(cur_str, NULL);
+        if (cur_str == NULL) {
+            set_destroy(set);
+            fprintf(stderr,"mmv: error opening '%s': %s\n", args[i], strerror(errno));
+            return NULL;
+        }
 
         if (set_insert(cur_str, set, track_dupes) == -1)
         {
             set_destroy(set);
             fprintf(stderr, "mmv: failed to insert \'%s\': %s\n", cur_str, strerror(errno));
+            free(cur_str);
             return NULL;
         }
     }

--- a/src/utils.c
+++ b/src/utils.c
@@ -3,7 +3,7 @@
 char *cpy_str_to_arr(char **arr_dest, const char *src_str)
 {
     *arr_dest = malloc((strlen(src_str) + 1) * sizeof(char));
-    if (arr_dest == NULL)
+    if (*arr_dest == NULL)
     {
         perror("mmv: failed to allocate memory for new map str\n");
         return NULL;
@@ -20,6 +20,10 @@ char *strccat(char **str_arr, unsigned int num_strs)
     unsigned int i;
     size_t size      = 4200 * sizeof(char);
     char *concat_str = malloc(size);
+    if (concat_str == NULL) {
+      perror("mmv: couldn't allocate concat str");
+      return NULL;
+		}
 
     char *p = memccpy(concat_str, str_arr[0], '\0', size - 1);
 


### PR DESCRIPTION
fixed a memory leak in init_src_set() caused by not freeing realpath_set before its replaced.

replaced usages of free(src_set) with set_destroy() to properly free sets.

is_valid_key(j) before get_set_pos(dest_set,j) to avoid reading out of bounds, removes a heap-buffer-overflow caught by fsanitize.

added more error checking

previously mmv would segfault if you tried to open a non existant file. This was caused by cpy_str_to_arr() calling strlen() with a NULL pointer leading to a segfault.

This is fixed by checking realpath()'s return value instead of directly sending it to cpy_str_to_arr().

add -g and fsanitize to debug builds

-g adds debug symbols and -fsanitize checks for memory issues as well as undefined behavior.

There is still a memory leak that needs to be resolved,
```c
//src/mmv.c

// line 136
struct Set *set = set_init(false, dest_size, dest_arr,true);
```
 set_init(true...);
avoids the memory leak but set_init(false...) shouldn't leak. I tried resolving it but it was too time consuming and not an issue that makes the program unusable for me.

From debugging I think this is leaking the names of files because running mmv with smaller file names leaks less.

you can view this memory leak by running the debug build or by adding the -g flag and running it in valgrind. 

Thanks for the cool program!